### PR TITLE
Fix pip package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Gianluca Zuccarelli',
     author_email='20079110@mail.wit.ie',
     license='unlicense',
-    packages=['src'],
+    packages=['nnssa'],
+    package_dir={'nnssa', 'src/'}
     zip_safe=False
 )


### PR DESCRIPTION
Import package name was incorrectly set to `src`.